### PR TITLE
Prohibit restart of docker or containerd services

### DIFF
--- a/scripts/policy-rc.d
+++ b/scripts/policy-rc.d
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Intended to be used as /usr/sbin/policy-rc.d on Debian and derivatives
+# Prohibits restarts of Docker and containerd services during package upgrades
+#
+
+readonly service="$1"
+readonly action="$2"
+
+case "$action" in
+  stop|restart)
+    case "$service" in
+      # prohibit docker/containerd stops or restarts
+      docker|containerd)
+        echo "*** System restart required for ${service} upgrade ***" >> /var/run/reboot-required
+        exit 101
+        ;;
+    esac
+    ;;
+esac
+
+# Allow actions other than stop/restart
+exit 0

--- a/scripts/update-packages.sh
+++ b/scripts/update-packages.sh
@@ -19,6 +19,11 @@ list_packages_deb() {
   .venv/bin/python3 "./update_exporter_deb.py" "$prometheus_push_gateway"
 }
 
+install_policy_rc_d() {
+  log info "Installing /usr/sbin/policy-rc.d"
+  cp "$(dirname "$0")/policy-rc.d" /usr/sbin/policy-rc.d
+}
+
 apt_get_upgrade() {
   log info "Doing package upgrade"
   if ! apt-get -qy dist-upgrade --auto-remove --purge; then
@@ -62,6 +67,7 @@ fi
 case "${ID}" in
   ubuntu)
     log info "Detected Ubuntu ${VERSION}"
+    install_policy_rc_d
     apt_get_upgrade
     list_packages_deb
     check_do_reboot


### PR DESCRIPTION
When doing package upgrades, services get restarted by default. For most services this is not an issue. However, restarting Docker or containerd will leave the system in a state where dpkg doesn't work, since a Docker
or containerd restart will terminate the container running the apt-get upgrade in the middle of the process.

This commit adds a [policy-rc.d] script which prohibits stops or restarts of the docker and containerd system services. The package upgrade script will install the provided policy-rc.d script as /usr/sbin/policy-rc.d before doing package upgrades.

The policy-rc.d script ensures that /var/run/reboot-required exists if either Docker or containerd was upgraded (as indicated by the call to the policy-rc.d script for the service stop or restart). By creating /var/run/reboot-required the code that triggers a node reboot after the package updates is triggered when Docker and/or containerd are upgraded.

Resolves #9

[policy-rc.d]: https://people.debian.org/~hmh/invokerc.d-policyrc.d-specification.txt