### PR TITLE
Implement optional apt-get update during maintenance window

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -12,6 +12,18 @@ cp -r /var/lib/apt/lists/* /host/var/lib/apt/lists
 
 cp /etc/apt/sources.list /host/etc/apt/sources.list
 
+while getopts "u" opt; do
+    case "${opt}" in
+        u)
+            aptupdate=1
+            ;;
+        *)
+            echo "Usage $0 [-u] [PUSHGATEWAY]"
+            ;;
+    esac
+done
+shift $((OPTIND -1))
+
 log info "Get IP address of the push gateway"
 
 host=$(echo "$1" | cut -d ':' -f 1)
@@ -27,10 +39,17 @@ port=$(echo "$1" | cut -d ':' -f 2)
 
 log info "Found: $pgw"
 
+# Don't do apt-get update during maintenance window by default
+[ -z "$aptupdate" ] && aptupdate=0
+
+if [ "$aptupdate" -eq 1 ]; then
+    log info "User requested apt-get update during maintenance window"
+fi
+
 log info "Copy update script to host"
 
 cp -r /scripts/. /host/tmp/
 
 log info "Chrooting and update"
 
-chroot /host bash /tmp/update-packages.sh "$pgw"
+chroot /host bash /tmp/update-packages.sh "$pgw" "$aptupdate"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -27,8 +27,8 @@ shift $((OPTIND -1))
 log info "Get IP address of the push gateway"
 
 host=$(echo "$1" | cut -d ':' -f 1)
-port=$(echo "$1" | cut -d ':' -f 2)
-[ -n "$1" ] && pgw=$(dig +short "$host")
+port=$(echo "$1" | cut -d ':' -f 2 -s)
+[ -n "$1" ] && pgw=$(dig +short "$host" | tail -1)
 # If it's still empty it was either:
 # empty to begin with
 # an IP address

--- a/scripts/update-packages.sh
+++ b/scripts/update-packages.sh
@@ -24,6 +24,16 @@ install_policy_rc_d() {
   cp "$(dirname "$0")/policy-rc.d" /usr/sbin/policy-rc.d
 }
 
+apt_get_update() {
+  log info "Updating package lists"
+  if ! apt-get update; then
+    log error "Updating package lists failed"
+    exit 1
+  fi
+
+  log info "Package lists updated"
+}
+
 apt_get_upgrade() {
   log info "Doing package upgrade"
   if ! apt-get -qy dist-upgrade --auto-remove --purge; then
@@ -68,6 +78,9 @@ case "${ID}" in
   ubuntu)
     log info "Detected Ubuntu ${VERSION}"
     install_policy_rc_d
+    if [ "$2" -eq 1 ]; then
+      apt_get_update
+    fi
     apt_get_upgrade
     list_packages_deb
     check_do_reboot


### PR DESCRIPTION
This provides a short-term workaround for #14 for users who don't particularly care about having reproducible upgrades throughout the week until we've determined how we want to address the root cause for that issue.