### PR TITLE
Conditionally populate apt package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@ Also contains a sample Grafana Dashboard and some bootstrapping scripts to setup
 The Grafana folder contains an example dashboard for SUC monitoring. Requires a working Prometheus/Grafana setup.
 
 testing contains some scripts and test objects useful for development and, you guessed it, testing.
+
+## Usage
+
+```bash
+/scripts/run.sh [-u] [pushgateway_url]
+```
+
+Arguments:
+* `-u`: Run `apt-get upgrade` during maintenance window, otherwise use cached package lists from Docker image.
+* `pushgateway_url`: URL of Prometheus pushgateway. Used to push detailed upgrade job metrics into Prometheus.


### PR DESCRIPTION
Only populate apt package lists from Docker image when user did not request `apt-get update` during maintenance window.

This should avoid errors like

```
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/bionic-updates/main/binary-i386/Packages.xz  File has unexpected size (1252932 != 1240764). Mirror sync in progress? [IP: 91.189.88.152 80]
   Hashes of expected file:
    - Filesize:1240764 [weak]
    - SHA256:53f7b8dd3380bb37b832160aa4478cdbd6c94788649764ef6ceebc7d9fbccb59
    - SHA1:68abd0e4473cbf903c97fa84415398a85f218a96 [weak]
    - MD5Sum:7631afd9937b6d9a752510b8914ee702 [weak]
   Release file created at: Mon, 22 Mar 2021 08:02:51 +0000
```

when running the script with `-u`.

Additionally add "Usage" section in README.md
