### PR TITLE
Fix policy-rc.d script to correctly work with deb-systemd-invoke

### DIFF
--- a/scripts/policy-rc.d
+++ b/scripts/policy-rc.d
@@ -10,8 +10,13 @@ readonly action="$2"
 case "$action" in
   stop|restart)
     case "$service" in
-      # prohibit docker/containerd stops or restarts
-      docker|containerd)
+      # prohibit docker/containerd stops or restarts.
+      #
+      # For packages which use deb-systemd-invoke, the full systemd unit name
+      # (including the service suffix) is passed to this script as the value
+      # for $service. Therefore we match on any value for service which
+      # *starts with* docker or containerd.
+      docker*|containerd*)
         echo "*** System restart required for ${service} upgrade ***" >> /var/run/reboot-required
         exit 101
         ;;


### PR DESCRIPTION
Packages which use `invoke-rc.d` to perform service stops/restarts pass the **service name** to `policy-rc.d` as `$service`, so the previous version of this script works correctly for these packages. However, packages which use [`deb-systemd-invoke`] pass the full systemd unit name (including the service suffix) to policy-rc.d as the value for `$service`.

This commit -- to make our `policy-rc.d` compatible with `deb-systemd-invoke` -- prohibits restarts and stops for any values of
`$service` which **start with** "docker" or "containerd" instead of only prohibiting restarts and stops for values which are equal to "docker" or "containerd".

[`deb-systemd-invoke`]: http://manpages.ubuntu.com/manpages/bionic/man1/deb-systemd-invoke.1p.html

Fixes #9 for services which use `deb-systemd-invoke` instead of `invoke-rc.d`.