### PR TITLE
Ignore error return codes from `update_exporter_deb.py`

### DIFF
--- a/scripts/update-packages.sh
+++ b/scripts/update-packages.sh
@@ -16,7 +16,10 @@ list_packages_deb() {
   cd "$(dirname "$0")"
   # shellcheck disable=SC1091
   . .venv/bin/activate
-  .venv/bin/python3 "./update_exporter_deb.py" "$prometheus_push_gateway"
+  # We want to ignore error return codes from `update_exporter_deb.py` since
+  # failing to push an update to Prometheus shouldn't fail the maintenance for
+  # a node.
+  .venv/bin/python3 "./update_exporter_deb.py" "$prometheus_push_gateway" || true
 }
 
 install_policy_rc_d() {

--- a/scripts/update_exporter_deb.py
+++ b/scripts/update_exporter_deb.py
@@ -1,6 +1,7 @@
 from datetime import date
 import argparse
 import socket
+import sys
 from prometheus_client import CollectorRegistry, Gauge, pushadd_to_gateway, instance_ip_grouping_key
 
 
@@ -35,8 +36,12 @@ def main():
                 version = splitted_line[5].strip()
                 g.labels(package, version, 'apt').set(1)
 
-    pushadd_to_gateway(args.url, job='suc', registry=registry,
-                       grouping_key={'instance': socket.gethostname()})
+    try:
+        pushadd_to_gateway(args.url, job='suc', registry=registry,
+                           grouping_key={'instance': socket.gethostname()})
+    except Exception as e:
+        print(f'Unable to push metrics to push gateway at {args.url}: {e}')
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We ignore errors when trying to push the updated packages to Prometheus, since a failure of that process shouldn't fail the maintenance job for a node.


Additionally, we catch exceptions thrown by `pushadd_to_gateway()` in `update_exporter_deb.py` and present the errors in a nicer format. Note that we still exit the Python script with an error, but since we ignore errors in `update-packages.sh` this should still ensure that failures when communicating with the push gateway don't fail the maintenance job.

Fixes #15