### PR TITLE
Add step which creates dummy commit to keep scheduled action active

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,9 @@ jobs:
         run: docker build --build-arg ubuntu_version=${{ matrix.ubuntu_version }} -t projectsyn/suc-ubuntu-${{ matrix.ubuntu_name }}:$TAG .
       - name: Push Image
         run: docker push projectsyn/suc-ubuntu-${{ matrix.ubuntu_name }}:$TAG
+      - name: GitHub Actions Keepalive
+        uses: gautamkrishnar/keepalive-workflow@1.0.7
+        with:
+          commit_message: Dummy commit to keep GitHub actions active
+          committer_username: github-actions
+          committer_email: tech+github-actions@vshn.ch


### PR DESCRIPTION
We use https://github.com/gautamkrishnar/keepalive-workflow to create an empty dummy commit if there's been no activity on the repo for 50 days to ensure the scheduled action is not deactivated.

Fixes #20