### PR TITLE
Only execute the GitHub keepalive for one image build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Push Image
         run: docker push projectsyn/suc-ubuntu-${{ matrix.ubuntu_name }}:$TAG
       - name: GitHub Actions Keepalive
+        # Only execute keepalive on scheduled runs and only for one matrix
+        # element.
+        if: ${{ github.event_name == 'schedule' && matrix.ubuntu_name == 'focal' }}
         uses: gautamkrishnar/keepalive-workflow@1.0.7
         with:
           commit_message: Dummy commit to keep GitHub actions active


### PR DESCRIPTION
Only run the Keepalive step for scheduled runs for the Ubuntu 20.04 (focal) image. Otherwise we may get duplicate keepalive commits on the repo.