### PR TITLE
Default to doing `apt-get update` during maintenance window

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ testing contains some scripts and test objects useful for development and, you g
 ```
 
 Arguments:
-* `-u`: Run `apt-get update` during maintenance window, otherwise use cached package lists from Docker image.
+* `-p`: Don't run `apt-get update` during maintenance window, but use cached package lists from Docker image.
 * `-s`: Don't override the sources.list on the host with the one from the docker image.
 * `pushgateway_url`: URL of Prometheus pushgateway. Used to push detailed upgrade job metrics into Prometheus.
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -5,10 +5,14 @@ set -e
 #shellcheck disable=SC1091
 . /scripts/functions.sh
 
-while getopts "us" opt; do
+while getopts "ups" opt; do
     case "${opt}" in
         u)
-            aptupdate=1
+            log warn "The flag '-u' is deprecated and script does apt-get update by default"
+            ;;
+        p)
+          # Use cached apt package list
+            aptupdate=0
             ;;
         s)  sourcelist=1
             ;;
@@ -19,8 +23,8 @@ while getopts "us" opt; do
 done
 shift $((OPTIND -1))
 
-# Don't do apt-get update during maintenance window by default
-[ -z "$aptupdate" ] && aptupdate=0
+# Do apt-get update during maintenance window by default
+[ -z "$aptupdate" ] && aptupdate=1
 
 # Override the host source list with the source list of the docker image
 [ -z "$sourcelist" ] && sourcelist=0

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -8,7 +8,7 @@ set -e
 while getopts "ups" opt; do
     case "${opt}" in
         u)
-            log warn "The flag '-u' is deprecated and script does apt-get update by default"
+            log warn "The flag '-u' is deprecated. The script does apt-get update by default. Use -p to use the package lists from the image."
             ;;
         p)
           # Use cached apt package list


### PR DESCRIPTION
We decided not to run Ubuntu package mirror and to live with losing the patchlevel uniformity throughout the week.

We now run `apt update` during the maintenance window by default. Users may disable this `apt update` with the `-p` flag.

Closes #14 