### PR TITLE
Update workflow runner to `ubuntu-latest`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   builds:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:


### PR DESCRIPTION
GitHub has deprecated support for Ubuntu 18.04 runners a while ago (cf. https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/). Since we don't really care which Ubuntu version we're running the Docker builds on, we just switch to `ubuntu-latest` for the runners.